### PR TITLE
fix: apply output file mode at creation time

### DIFF
--- a/src/command/inject.rs
+++ b/src/command/inject.rs
@@ -1,6 +1,4 @@
-use std::fs::File;
-use std::io::{self, Read, Write};
-use std::os::unix::fs::PermissionsExt;
+use std::io::{self, Read};
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
@@ -75,9 +73,10 @@ pub struct InjectArgs {
         long = "file-mode",
         value_name = "filemode",
         value_parser = parse_file_mode,
+        default_value = "600",
         help = "Set file mode for the output file (octal, ignored without --out-file)"
     )]
-    pub file_mode: Option<u32>,
+    pub file_mode: u32,
 
     #[clap(short = 'f', long = "force", help = "Do not prompt for confirmation")]
     pub force: bool,
@@ -149,16 +148,7 @@ pub fn execute(args: InjectArgs) -> Result<()> {
     };
 
     if let Some(out_file) = &args.out_file {
-        let mut file = File::create(out_file)
-            .with_context(|| format!("Failed to create output file: {:?}", out_file))?;
-
-        file.write_all(output.as_bytes())?;
-
-        if let Some(mode) = args.file_mode {
-            use std::fs;
-            fs::set_permissions(out_file, PermissionsExt::from_mode(mode))
-                .with_context(|| format!("Failed to set file mode: {:o}", mode))?;
-        }
+        crate::output::write_secret_file(out_file, output.as_bytes(), args.file_mode)?;
     } else {
         print!("{}", output);
     }

--- a/src/command/read.rs
+++ b/src/command/read.rs
@@ -1,6 +1,3 @@
-use std::fs::File;
-use std::io::Write;
-use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
@@ -91,13 +88,7 @@ pub fn execute(args: ReadArgs) -> Result<()> {
     };
 
     if let Some(out_file) = &args.out_file {
-        let mut file = File::create(out_file)
-            .with_context(|| format!("Failed to create file: {:?}", out_file))?;
-        file.write_all(value.as_bytes())?;
-
-        use std::fs;
-        fs::set_permissions(out_file, PermissionsExt::from_mode(args.file_mode))
-            .with_context(|| format!("Failed to set file mode: {:o}", args.file_mode))?;
+        crate::output::write_secret_file(out_file, value.as_bytes(), args.file_mode)?;
     } else if args.no_newline {
         print!("{}", value);
     } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use clap::Parser;
 mod command;
 mod config;
 mod delegate;
+mod output;
 mod store;
 mod template;
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,0 +1,84 @@
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+use std::path::Path;
+
+use anyhow::{Context, Result};
+
+/// Write secret material to a file such that it is never observable with
+/// permissions broader than `mode`. The file is created with `mode` applied
+/// at open time (not chmod'd after the contents are written), and pre-existing
+/// files are re-permissioned after truncation, before the contents land.
+pub fn write_secret_file(path: &Path, contents: &[u8], mode: u32) -> Result<()> {
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(mode)
+        .open(path)
+        .with_context(|| format!("Failed to create file: {:?}", path))?;
+
+    // The open-time mode only applies to newly created files and is subject to
+    // umask; enforce it exactly (covering pre-existing files) while the file
+    // is still empty.
+    fs::set_permissions(path, fs::Permissions::from_mode(mode))
+        .with_context(|| format!("Failed to set file mode: {:o}", mode))?;
+
+    file.write_all(contents)
+        .with_context(|| format!("Failed to write file: {:?}", path))?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+    fn temp_path() -> PathBuf {
+        let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+        std::env::temp_dir().join(format!(
+            "op-fast-output-test-{}-{}",
+            std::process::id(),
+            n
+        ))
+    }
+
+    fn mode_of(path: &Path) -> u32 {
+        fs::metadata(path).unwrap().permissions().mode() & 0o777
+    }
+
+    #[test]
+    fn creates_file_with_exact_mode_and_contents() {
+        let path = temp_path();
+        write_secret_file(&path, b"hunter2", 0o600).unwrap();
+        assert_eq!(mode_of(&path), 0o600);
+        assert_eq!(fs::read(&path).unwrap(), b"hunter2");
+        fs::remove_file(&path).unwrap();
+    }
+
+    #[test]
+    fn honors_custom_mode() {
+        let path = temp_path();
+        write_secret_file(&path, b"public", 0o644).unwrap();
+        assert_eq!(mode_of(&path), 0o644);
+        fs::remove_file(&path).unwrap();
+    }
+
+    #[test]
+    fn tightens_permissions_of_pre_existing_file_before_rewriting() {
+        let path = temp_path();
+        fs::write(&path, b"old world-readable contents").unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).unwrap();
+
+        write_secret_file(&path, b"new secret", 0o600).unwrap();
+        assert_eq!(mode_of(&path), 0o600);
+        assert_eq!(fs::read(&path).unwrap(), b"new secret");
+        fs::remove_file(&path).unwrap();
+    }
+}


### PR DESCRIPTION
`read -o` and `inject -o` create the output file with default umask permissions, write the secret, then chmod. On a typical umask the secret sits world-readable until the chmod lands, and `inject -o` without `--file-mode` never tightens it at all — the resolved config keeps 644 permanently.

This opens the file with the target mode applied at open time (`OpenOptions::mode`), then enforces the exact mode while the file is still empty, covering pre-existing files and umask interference. The write happens only after permissions are correct. `inject -o` now defaults to 600 like `read -o`; that's a behavior change for anyone relying on umask output, so happy to gate it behind a flag if you'd rather keep the old default there.

Includes tests for creation mode, custom `--file-mode`, and rewriting a pre-existing 644 file.