### PR TITLE
fix: batch inject can mis-assign values across references

### DIFF
--- a/src/delegate.rs
+++ b/src/delegate.rs
@@ -65,11 +65,8 @@ impl OpDelegate {
             return Ok(HashMap::new());
         }
 
-        let template: String = references
-            .iter()
-            .map(|r| r.to_string())
-            .collect::<Vec<_>>()
-            .join("\n");
+        let tag = std::process::id();
+        let template = build_batch_template(references, tag);
 
         let mut child = Command::new(&self.command)
             .arg("inject")
@@ -97,19 +94,11 @@ impl OpDelegate {
         let stdout =
             String::from_utf8(output.stdout).context("op inject returned non-UTF8 output")?;
 
-        let values: Vec<&str> = stdout.lines().collect();
-
-        if values.len() != references.len() {
-            bail!(
-                "op inject returned {} values for {} references",
-                values.len(),
-                references.len()
-            );
-        }
+        let values = parse_batch_output(&stdout, references.len(), tag)?;
 
         let mut result = HashMap::new();
-        for (reference, value) in references.iter().zip(values.iter()) {
-            result.insert(reference.to_string(), value.to_string());
+        for (reference, value) in references.iter().zip(values) {
+            result.insert(reference.to_string(), value);
         }
 
         Ok(result)
@@ -117,5 +106,170 @@ impl OpDelegate {
 
     pub fn command(&self) -> Command {
         Command::new(&self.command)
+    }
+}
+
+fn sentinel(tag: u32, index: usize, end: bool) -> String {
+    let kind = if end { "END" } else { "BEGIN" };
+    format!("--OPFAST:{}:{}:{}--", tag, kind, index)
+}
+
+pub(crate) fn build_batch_template(references: &[&str], tag: u32) -> String {
+    let mut template = String::new();
+    for (i, reference) in references.iter().enumerate() {
+        template.push_str(&sentinel(tag, i, false));
+        template.push('\n');
+        template.push_str(reference);
+        template.push('\n');
+        template.push_str(&sentinel(tag, i, true));
+        template.push('\n');
+    }
+    template
+}
+
+pub(crate) fn parse_batch_output(output: &str, expected: usize, tag: u32) -> Result<Vec<String>> {
+    let mut values: Vec<String> = Vec::with_capacity(expected);
+    let mut current: Option<Vec<&str>> = None;
+
+    for line in output.lines() {
+        match &mut current {
+            None => {
+                if line == sentinel(tag, values.len(), false) {
+                    current = Some(Vec::new());
+                } else {
+                    bail!("op inject output contains unexpected content outside a sentinel section");
+                }
+            }
+            Some(lines) => {
+                if line == sentinel(tag, values.len(), true) {
+                    values.push(lines.join("\n"));
+                    current = None;
+                } else if line.starts_with(&format!("--OPFAST:{}:", tag)) {
+                    // A sentinel for this tag in the wrong position means a
+                    // value contained forged markers; refuse rather than risk
+                    // shifted assignments.
+                    bail!("op inject output contains a misplaced sentinel marker");
+                } else {
+                    lines.push(line);
+                }
+            }
+        }
+    }
+
+    if current.is_some() {
+        bail!("op inject output ended inside an unterminated sentinel section");
+    }
+    if values.len() != expected {
+        bail!(
+            "op inject returned {} sections for {} references",
+            values.len(),
+            expected
+        );
+    }
+
+    Ok(values)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Simulate what `op inject` produces for a template: each reference line
+    // replaced by its value, all other lines passed through verbatim.
+    fn simulate_inject(template: &str, values: &[&str]) -> String {
+        let mut out = String::new();
+        let mut value_iter = values.iter();
+        for line in template.lines() {
+            if line.starts_with("op://") {
+                out.push_str(value_iter.next().expect("more refs than values"));
+            } else {
+                out.push_str(line);
+            }
+            out.push('\n');
+        }
+        out
+    }
+
+    #[test]
+    fn template_wraps_each_reference_in_sentinels() {
+        let template = build_batch_template(&["op://a/b/c", "op://d/e/f"], 42);
+        assert_eq!(
+            template,
+            "--OPFAST:42:BEGIN:0--\nop://a/b/c\n--OPFAST:42:END:0--\n\
+             --OPFAST:42:BEGIN:1--\nop://d/e/f\n--OPFAST:42:END:1--\n"
+        );
+    }
+
+    #[test]
+    fn parse_assigns_single_line_values_in_order() {
+        let refs = ["op://a/b/c", "op://d/e/f"];
+        let template = build_batch_template(&refs, 7);
+        let output = simulate_inject(&template, &["first", "second"]);
+        let values = parse_batch_output(&output, 2, 7).unwrap();
+        assert_eq!(values, vec!["first".to_string(), "second".to_string()]);
+    }
+
+    #[test]
+    fn parse_preserves_multi_line_values() {
+        let refs = ["op://vault/ssh/key"];
+        let template = build_batch_template(&refs, 7);
+        let output = simulate_inject(&template, &["-----BEGIN KEY-----\nabc\n-----END KEY-----"]);
+        let values = parse_batch_output(&output, 1, 7).unwrap();
+        assert_eq!(values, vec!["-----BEGIN KEY-----\nabc\n-----END KEY-----".to_string()]);
+    }
+
+    #[test]
+    fn parse_empty_value_yields_empty_string() {
+        let refs = ["op://a/b/c"];
+        let template = build_batch_template(&refs, 7);
+        let output = simulate_inject(&template, &[""]);
+        let values = parse_batch_output(&output, 1, 7).unwrap();
+        assert_eq!(values, vec![String::new()]);
+    }
+
+    #[test]
+    fn parse_regression_multiline_plus_empty_do_not_misassign() {
+        // The upstream line-count bug: value "x\ny" plus value "" produced two
+        // lines for two refs and mis-assigned "y" to the second reference.
+        let refs = ["op://a/b/c", "op://d/e/f"];
+        let template = build_batch_template(&refs, 7);
+        let output = simulate_inject(&template, &["x\ny", ""]);
+        let values = parse_batch_output(&output, 2, 7).unwrap();
+        assert_eq!(values, vec!["x\ny".to_string(), String::new()]);
+    }
+
+    #[test]
+    fn parse_fails_on_missing_end_marker() {
+        let output = "--OPFAST:7:BEGIN:0--\nvalue\n";
+        assert!(parse_batch_output(output, 1, 7).is_err());
+    }
+
+    #[test]
+    fn parse_fails_on_section_count_mismatch() {
+        let refs = ["op://a/b/c"];
+        let template = build_batch_template(&refs, 7);
+        let output = simulate_inject(&template, &["only"]);
+        assert!(parse_batch_output(&output, 2, 7).is_err());
+    }
+
+    #[test]
+    fn parse_fails_closed_when_a_value_forges_aligned_sentinels() {
+        // Hostile value 0 forges an early END:0 plus a BEGIN:1 so that the
+        // real markers land inside section 1 and the section count still
+        // matches. Must error - never return shifted/garbage assignments.
+        let refs = ["op://a/b/c", "op://d/e/f"];
+        let template = build_batch_template(&refs, 7);
+        let forged = "real\n--OPFAST:7:END:0--\n--OPFAST:7:BEGIN:1--\nPWNED";
+        let output = simulate_inject(&template, &[forged, "actual"]);
+        assert!(parse_batch_output(&output, 2, 7).is_err());
+    }
+
+    #[test]
+    fn parse_fails_on_unexpected_content_outside_sections() {
+        let refs = ["op://a/b/c"];
+        let template = build_batch_template(&refs, 7);
+        let mut output = String::from("unexpected preamble\n");
+        output.push_str(&simulate_inject(&template, &["value"]));
+        assert!(parse_batch_output(&output, 1, 7).is_err());
     }
 }


### PR DESCRIPTION
`read_batch` joins references with newlines and zips `op inject`'s output back by line count. Two problems fall out:

1. A multi-line secret plus an empty-valued field in the same batch can line up coincidentally and pass the count check while assigning the wrong values. Repro: batch `[ref_a, ref_b]` where a's value is `"x\ny"` and b's is `""` — the output is two lines, so a gets `"x"` and b gets `"y"`, and both wrong values are then cached under those references.
2. Any multi-line secret (SSH keys, PEM blocks, notes) fails the count check even when nothing is ambiguous.

This wraps each reference between per-invocation sentinel markers (tagged with the caller pid) in the inject template and parses strictly between them. Multi-line and empty values round-trip correctly, and any unexpected structure — including a value that happens to contain a marker-shaped line — fails closed with an error rather than risking shifted assignments.

Tests cover ordering, multi-line values, empty values, the mis-assignment repro above, and forged/misplaced markers.